### PR TITLE
⬆️ Bump actions/setup-node from 4.0.1 to 4.0.2 (#32)

### DIFF
--- a/.github/workflows/deploy-app-sync.yml
+++ b/.github/workflows/deploy-app-sync.yml
@@ -19,7 +19,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5.0.0
       - name: setup Node.js
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 18
           cache: npm
@@ -34,7 +34,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.MY_AWS_REGION }}
       - name: build
         run: sam build
         working-directory: ./sam/2.app-sync

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up Node.js
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
           cache: npm
@@ -32,7 +32,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.MY_AWS_REGION }}
       - name: upload files to S3
         working-directory: ./client
         run: aws s3 cp --recursive dist/ s3://${{env.AWS_S3_BUCKET}}/ --exclude '.*git*'

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up Node.js
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up Node.js
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
* :arrow_up: Bump actions/setup-node from 4.0.1 to 4.0.2

Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4.0.1 to 4.0.2.
- [Release notes](https://github.com/actions/setup-node/releases)
- [Commits](https://github.com/actions/setup-node/compare/v4.0.1...v4.0.2)

---
updated-dependencies:
- dependency-name: actions/setup-node dependency-type: direct:production update-type: version-update:semver-patch ...



* :wrench: update GitHub Actions

---------