### PR TITLE
画面追加系の操作の不便さを解消

### DIFF
--- a/client/src/PaneLayoutTemplate/index.ts
+++ b/client/src/PaneLayoutTemplate/index.ts
@@ -24,24 +24,29 @@ module Scope {
 }
 
 export async function addDashboards(graphQlStore: GraphQlStore, sessionType: string): Promise<string> {
-  const waitDashboardNum = (num: number): Promise<void> => {
-    return new Promise((resolve: () => void) => {
+  const waitDashboard = (dashboardName: string): Promise<string> => {
+    return new Promise((resolve: (dashboardId: string) => void) => {
       const timerId = setInterval(() => {
-        const dashboardNum = graphQlStore.state.dashboards.length
-        if (dashboardNum === num) {
+        const dashboard = graphQlStore.state.dashboards.find(d => d.name === dashboardName)
+        if (dashboard) {
           clearInterval(timerId)
-          resolve()
+          resolve(dashboard.id)
         }
-      }, 200)
+      }, 100)
     })
   }
+  let defaultDashboardId: string | null = null
   if (sessionType === 'Shinobigami') {
     await graphQlStore.addDashboard('シナリオデータ管理', ScenarioDataManagePaneLayout, Scope.OWNER)
     await graphQlStore.addDashboard('キャラクターシート管理', CharacterSheetManagePaneLayout, Scope.ALL)
     await graphQlStore.addDashboard('データ閲覧', DataViewPaneLayout, Scope.ALL)
     await graphQlStore.addDashboard('特技比較', SpecialityTableDiffPaneLayout, Scope.ALL)
-    await waitDashboardNum(4)
-    return graphQlStore.state.dashboards.find(d => d.name === 'データ閲覧')?.id || ''
+    defaultDashboardId = await waitDashboard('データ閲覧')
+  }
+  if (defaultDashboardId) {
+    const sessionName = graphQlStore?.state.session?.name || ''
+    await graphQlStore.updateSession(sessionName, sessionType, defaultDashboardId)
+    await graphQlStore.directDashboardAccess(defaultDashboardId)
   }
   return ''
 }

--- a/client/src/components/graphql/graphql.ts
+++ b/client/src/components/graphql/graphql.ts
@@ -1183,17 +1183,6 @@ export default function useGraphQl(userToken: string, playerToken: string, sessi
             option: JSON.parse(data.option) as DashboardOption
           }
           state.dashboards.push(dashboard)
-          if (state.dashboard) {
-            state.dashboard.layout = null
-          }
-          setTimeout(() => {
-            state.dashboard = {
-              ...dashboard,
-              layout: JSON.parse(data.layout) as Layout,
-              option: JSON.parse(data.option) as DashboardOption
-            }
-            state.dashboardCache.set(state.dashboard.id, clone<Dashboard>(state.dashboard)!)
-          })
         }
       },
       error(errorValue: any) {

--- a/client/src/components/graphql/graphql.ts
+++ b/client/src/components/graphql/graphql.ts
@@ -825,7 +825,7 @@ export default function useGraphQl(userToken: string, playerToken: string, sessi
         }
         state.dashboardCache.set(state.dashboard.id, clone<Dashboard>(state.dashboard)!)
       } else {
-        await directDashboardAccess(dashboardId)
+        await directDashboardAccess(dashboardId || data.defaultDashboard.id)
       }
     } else {
       state.dashboard = null

--- a/client/src/components/view/SessionView.vue
+++ b/client/src/components/view/SessionView.vue
@@ -349,9 +349,23 @@ async function onSubmitSessionType(sessionType: string): Promise<void> {
 
 async function addDashboard() {
   if (!graphQlStore) return
+  const beforeDashboards = graphQlStore?.state.dashboards.map(d => d.id)
   await graphQlStore.addDashboard(addDashboardName.value, defaultLayout, { scope: 'all' })
+  const getNewDashboard = (): Promise<string> => {
+    return new Promise((resolve: (newDashboardId: string) => void) => {
+      const timerId = setInterval(() => {
+        const newDashboard = graphQlStore.state.dashboards.find(ad => !beforeDashboards?.includes(ad.id))
+        if (newDashboard) {
+          clearInterval(timerId)
+          resolve(newDashboard.id)
+        }
+      }, 100)
+    })
+  }
+  const newDashboardId = await getNewDashboard()
   addDashboardName.value = DEFAULT_DASHBOARD_NAME
   addDashboardMenu.value = false
+  await graphQlStore.directDashboardAccess(newDashboardId)
 }
 
 const addDashboardNameElm = ref()

--- a/client/src/components/view/SessionView.vue
+++ b/client/src/components/view/SessionView.vue
@@ -341,10 +341,7 @@ onMounted(() => {
 
 async function onSubmitSessionType(sessionType: string): Promise<void> {
   if (!graphQlStore) return
-  const sessionName = graphQlStore?.state.session?.name || ''
-  const defaultDashboardId = graphQlStore?.state.session?.defaultDashboardId
-  const newDefaultDashboardId = await addDashboards(graphQlStore, sessionType)
-  await graphQlStore.updateSession(sessionName, sessionType, defaultDashboardId || newDefaultDashboardId)
+  await addDashboards(graphQlStore, sessionType)
 }
 
 async function addDashboard() {


### PR DESCRIPTION
- [[5ddb96e](https://github.com/HillTopTRPG/waddlefy/commit/5ddb96e437e577c3bc124acf3e73e15dc4c70c45)] 画面追加時に追加した主催者のみが新しい画面に遷移するようにした
- [[8ade213](https://github.com/HillTopTRPG/waddlefy/commit/8ade2139650ce7eb49a6552a6ee394da6e8e4c26)] 存在しない画面のURLにアクセスされた場合にセッションのデフォルト画面に遷移させるようにした
- [[8f6fd6b](https://github.com/HillTopTRPG/waddlefy/commit/8f6fd6bae1af6ce0e779ec2188caa2955a3e68d9)] タイプを指定してセッションの構築をする際に想定の画面が初期表示にならず、必ず最後の画面が初期表示になってしまっていた不具合の修正